### PR TITLE
php 5.3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+install:
+  - composer install
+
+script: vendor/bin/fu test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ php:
 install:
   - composer install
 
-script: vendor/bin/fu test
+script: bin/fu tests

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,8 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
     "hash": "2bbdd2393f13332683b4eacc0dcccd15",
     "packages": [
@@ -53,16 +54,16 @@
         },
         {
             "name": "nategood/commando",
-            "version": "0.2.5",
+            "version": "0.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nategood/commando.git",
-                "reference": "2b904d48b2296a099c2fd9fc2212eff9cfc0a7c5"
+                "reference": "873183f0062514ff8c50851f0d8ce98cbbd5ac72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nategood/commando/zipball/2b904d48b2296a099c2fd9fc2212eff9cfc0a7c5",
-                "reference": "2b904d48b2296a099c2fd9fc2212eff9cfc0a7c5",
+                "url": "https://api.github.com/repos/nategood/commando/zipball/873183f0062514ff8c50851f0d8ce98cbbd5ac72",
+                "reference": "873183f0062514ff8c50851f0d8ce98cbbd5ac72",
                 "shasum": ""
             },
             "require": {
@@ -82,8 +83,7 @@
             "authors": [
                 {
                     "name": "Nate Good",
-                    "email": "me@nategood.com",
-                    "homepage": "http://nategood.com"
+                    "email": "me@nategood.com"
                 }
             ],
             "description": "PHP CLI Commando Style",
@@ -96,23 +96,17 @@
                 "command line interface",
                 "scripting"
             ],
-            "time": "2014-02-02 20:46:29"
+            "time": "2015-01-05 15:55:41"
         }
     ],
-    "packages-dev": [
-
-    ],
-    "aliases": [
-
-    ],
+    "packages-dev": [],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/src/FUnit.php
+++ b/src/FUnit.php
@@ -891,8 +891,16 @@ class FUnit
      * @param  callable $callback [description]
      * @param string $msg optional description of assertion
      */
-    public static function assert_all_ok($a, callable $callback, $msg = null)
+    public static function assert_all_ok($a, $callback, $msg = null)
     {
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected callable argument. %s given',
+                is_object($callback) ? get_class($callback) : gettype($callback)
+            ));
+            
+        }
+
         if (is_array($a) || $a instanceof \Traversable) {
             $rs = true;
             $failed_val = null;
@@ -930,8 +938,16 @@ class FUnit
      * @param string $msg
      * @return bool
      */
-    public static function assert_throws(callable $callback, $params, $exception = null, $msg = null)
+    public static function assert_throws($callback, $params, $exception = null, $msg = null)
     {
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected callable argument. %s given',
+                is_object($callback) ? get_class($callback) : gettype($callback)
+            ));
+            
+        }
+
         if (is_array($params)) {
             $exception = $exception ?: 'Exception';
         } else {

--- a/tests/assertion_tests.php
+++ b/tests/assertion_tests.php
@@ -8,122 +8,195 @@ require_once __DIR__ . '/../src/FUnit.php';
 fu::suite('Assertion test suite');
 
 fu::test('FUnit::assert_ok tests', function () {
-    fu::strict_equal(true, fu::assert_ok(1)['result'], "1 is truthy");
-    fu::strict_equal(false, fu::assert_ok(0)['result'], "0 is falsy");
-    fu::strict_equal(false, fu::assert_ok("")['result'], "empty string is falsy");
-    fu::strict_equal(false, fu::assert_ok(array())['result'], "empty array is falsy");
-    fu::strict_equal(false, fu::assert_ok(null)['result'], "null is falsy");
-    fu::strict_equal(false, fu::assert_ok(false)['result'], "false is falsy");
-    fu::strict_equal(true, fu::assert_ok(true)['result'], "true is truthy");
-    fu::strict_equal(true, fu::assert_ok('false')['result'], "'false' is truthy");
-    fu::strict_equal(true, fu::assert_ok(new stdClass)['result'], "stdClass is truthy");
+    $assert = fu::assert_ok(1);
+    fu::strict_equal(true, $assert['result'], "1 is truthy");
+    $assert = fu::assert_ok(0);
+    fu::strict_equal(false, $assert['result'], "0 is falsy");
+    $assert = fu::assert_ok("");
+    fu::strict_equal(false, $assert['result'], "empty string is falsy");
+    $assert = fu::assert_ok(array());
+    fu::strict_equal(false, $assert['result'], "empty array is falsy");
+    $assert = fu::assert_ok(null);
+    fu::strict_equal(false, $assert['result'], "null is falsy");
+    $assert = fu::assert_ok(false);
+    fu::strict_equal(false, $assert['result'], "false is falsy");
+    $assert = fu::assert_ok(true);
+    fu::strict_equal(true, $assert['result'], "true is truthy");
+    $assert = fu::assert_ok('false');
+    fu::strict_equal(true, $assert['result'], "'false' is truthy");
+    $assert = fu::assert_ok(new stdClass);
+    fu::strict_equal(true, $assert['result'], "stdClass is truthy");
 });
 
 fu::test('FUnit::assert_not_ok tests', function () {
-    fu::strict_equal(false, fu::assert_not_ok(1)['result'], "1 is truthy");
-    fu::strict_equal(true, fu::assert_not_ok(0)['result'], "0 is falsy");
-    fu::strict_equal(true, fu::assert_not_ok("")['result'], "empty string is falsy");
-    fu::strict_equal(true, fu::assert_not_ok(array())['result'], "empty array is falsy");
-    fu::strict_equal(true, fu::assert_not_ok(null)['result'], "null is falsy");
-    fu::strict_equal(true, fu::assert_not_ok(false)['result'], "false is falsy");
-    fu::strict_equal(false, fu::assert_not_ok(true)['result'], "true is truthy");
-    fu::strict_equal(false, fu::assert_not_ok('false')['result'], "'false' is truthy");
-    fu::strict_equal(false, fu::assert_not_ok(new stdClass)['result'], "stdClass is truthy");
+    $assert = fu::assert_not_ok(1);
+    fu::strict_equal(false, $assert['result'], "1 is truthy");
+    $assert = fu::assert_not_ok(0);
+    fu::strict_equal(true, $assert['result'], "0 is falsy");
+    $assert = fu::assert_not_ok("");
+    fu::strict_equal(true, $assert['result'], "empty string is falsy");
+    $assert = fu::assert_not_ok(array());
+    fu::strict_equal(true, $assert['result'], "empty array is falsy");
+    $assert = fu::assert_not_ok(null);
+    fu::strict_equal(true, $assert['result'], "null is falsy");
+    $assert = fu::assert_not_ok(false);
+    fu::strict_equal(true, $assert['result'], "false is falsy");
+    $assert = fu::assert_not_ok(true);
+    fu::strict_equal(false, $assert['result'], "true is truthy");
+    $assert = fu::assert_not_ok('false');
+    fu::strict_equal(false, $assert['result'], "'false' is truthy");
+    $assert = fu::assert_not_ok(new stdClass);
+    fu::strict_equal(false, $assert['result'], "stdClass is truthy");
 });
 
 fu::test('FUnit::assert_all_ok tests', function () {
     $all_ints = array(1, 2, 3, 4, 5);
     $not_all_ints = array(1, 2, "3", 4, 5);
 
-    fu::strict_equal(true, fu::assert_all_ok($all_ints, function ($val) {
+    $assert = fu::assert_all_ok($all_ints, function ($val) {
         return is_int($val);
-    })['result'], "\$all_ints are all integers");
+    });
+    fu::strict_equal(true, $assert['result'], "\$all_ints are all integers");
 
-    fu::strict_equal(false, fu::assert_all_ok($not_all_ints, function ($val) {
+    $assert = fu::assert_all_ok($not_all_ints, function ($val) {
         return is_int($val);
-    })['result'], "\$not_all_ints are NOT all integers");
+    });
+    fu::strict_equal(false, $assert['result'], "\$not_all_ints are NOT all integers");
 });
 
 
 fu::test('FUnit::assert_equal tests', function () {
-    fu::strict_equal(true, fu::assert_equal(1, 1)['result'], "1 and 1 are 'equal'");
-    fu::strict_equal(true, fu::assert_equal("a", "a")['result'], "'a' and 'a' are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(new stdClass, new stdClass)['result'], "new stdClass and new stdClass are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(1, "1")['result'], "1 and '1' are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(1, true)['result'], "1 and true are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(null, 0)['result'], "null and 0 are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(false, null)['result'], "false and null are 'equal'");
-    fu::strict_equal(true, fu::assert_equal(array(), null)['result'], "array() and null are 'equal'");
-    fu::strict_equal(false, fu::assert_equal(array(), 1)['result'], "array() and 1 are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(1, 0)['result'], "1 and 1 are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal("a", "b")['result'], "'a' and 'b' are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(new stdClass, new ArrayObject)['result'], "new stdClass and new ArrayObject are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(1, "a")['result'], "1 and 'a' are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(0, true)['result'], "0 and true are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(null, 1)['result'], "null and 1 are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(true, null)['result'], "false and null are not 'equal'");
-    fu::strict_equal(false, fu::assert_equal(array('0'), null)['result'], "array('0') and null are not 'equal'");
+    $assert = fu::assert_equal(1, 1);
+    fu::strict_equal(true, $assert['result'], "1 and 1 are 'equal'");
+    $assert = fu::assert_equal("a", "a");
+    fu::strict_equal(true, $assert['result'], "'a' and 'a' are 'equal'");
+    $assert = fu::assert_equal(new stdClass, new stdClass);
+    fu::strict_equal(true, $assert['result'], "new stdClass and new stdClass are 'equal'");
+    $assert = fu::assert_equal(1, "1");
+    fu::strict_equal(true, $assert['result'], "1 and '1' are 'equal'");
+    $assert = fu::assert_equal(1, true);
+    fu::strict_equal(true, $assert['result'], "1 and true are 'equal'");
+    $assert = fu::assert_equal(null, 0);
+    fu::strict_equal(true, $assert['result'], "null and 0 are 'equal'");
+    $assert = fu::assert_equal(false, null);
+    fu::strict_equal(true, $assert['result'], "false and null are 'equal'");
+    $assert = fu::assert_equal(array(), null);
+    fu::strict_equal(true, $assert['result'], "array() and null are 'equal'");
+    $assert = fu::assert_equal(array(), 1);
+    fu::strict_equal(false, $assert['result'], "array() and 1 are not 'equal'");
+    $assert = fu::assert_equal(1, 0);
+    fu::strict_equal(false, $assert['result'], "'a' and 'b' are not 'equal'");
+    $assert = fu::assert_equal("a", "b");
+    fu::strict_equal(false, $assert['result'], "new stdClass and new ArrayObject are not 'equal'");
+    $assert = fu::assert_equal(new stdClass, new ArrayObject);
+    fu::strict_equal(false, $assert['result'], "1 and 'a' are not 'equal'");
+    $assert = fu::assert_equal(1, "a");
+    fu::strict_equal(false, $assert['result'], "0 and true are not 'equal'");
+    $assert = fu::assert_equal(0, true);
+    fu::strict_equal(false, $assert['result'], "null and 1 are not 'equal'");
+    $assert = fu::assert_equal(null, 1);
+    fu::strict_equal(false, $assert['result'], "false and null are not 'equal'");
+    $assert = fu::assert_equal(true, null);
+    fu::strict_equal(false, $assert['result'], "array('0') and null are not 'equal'");
+    $assert = fu::assert_equal(array('0'), null);
 });
 
 fu::test('FUnit::assert_not_equal tests', function () {
-    fu::strict_equal(false, fu::assert_not_equal(1, 1)['result'], "1 and 1 are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal("a", "a")['result'], "'a' and 'a' are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(new stdClass, new stdClass)['result'], "new stdClass and new stdClass are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(1, "1")['result'], "1 and '1' are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(1, true)['result'], "1 and true are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(null, 0)['result'], "null and 0 are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(false, null)['result'], "false and null are 'equal'");
-    fu::strict_equal(false, fu::assert_not_equal(array(), null)['result'], "array() and null are 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(array(), 1)['result'], "array() and 1 are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(1, 0)['result'], "1 and 1 are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal("a", "b")['result'], "'a' and 'b' are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(new stdClass, new ArrayObject)['result'], "new stdClass and new ArrayObject are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(1, "a")['result'], "1 and 'a' are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(0, true)['result'], "0 and true are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(null, 1)['result'], "null and 1 are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(true, null)['result'], "false and null are not 'equal'");
-    fu::strict_equal(true, fu::assert_not_equal(array('0'), null)['result'], "array('0') and null are not 'equal'");
+    $assert = fu::assert_not_equal(1, 1);
+    fu::strict_equal(false, $assert['result'], "1 and 1 are 'equal'");
+    $assert = fu::assert_not_equal("a", "a");
+    fu::strict_equal(false, $assert['result'], "'a' and 'a' are 'equal'");
+    $assert = fu::assert_not_equal(new stdClass, new stdClass);
+    fu::strict_equal(false, $assert['result'], "new stdClass and new stdClass are 'equal'");
+    $assert = fu::assert_not_equal(1, "1");
+    fu::strict_equal(false, $assert['result'], "1 and '1' are 'equal'");
+    $assert = fu::assert_not_equal(1, true);
+    fu::strict_equal(false, $assert['result'], "1 and true are 'equal'");
+    $assert = fu::assert_not_equal(null, 0);
+    fu::strict_equal(false, $assert['result'], "null and 0 are 'equal'");
+    $assert = fu::assert_not_equal(false, null);
+    fu::strict_equal(false, $assert['result'], "false and null are 'equal'");
+    $assert = fu::assert_not_equal(array(), null);
+    fu::strict_equal(false, $assert['result'], "array() and null are 'equal'");
+    $assert = fu::assert_not_equal(array(), 1);
+    fu::strict_equal(true, $assert['result'], "array() and 1 are not 'equal'");
+    $assert = fu::assert_not_equal(1, 0);
+    fu::strict_equal(true, $assert['result'], "1 and 1 are not 'equal'");
+    $assert = fu::assert_not_equal("a", "b");
+    fu::strict_equal(true, $assert['result'], "'a' and 'b' are not 'equal'");
+    $assert = fu::assert_not_equal(new stdClass, new ArrayObject);
+    fu::strict_equal(true, $assert['result'], "new stdClass and new ArrayObject are not 'equal'");
+    $assert = fu::assert_not_equal(1, "a");
+    fu::strict_equal(true, $assert['result'], "1 and 'a' are not 'equal'");
+    $assert = fu::assert_not_equal(0, true);
+    fu::strict_equal(true, $assert['result'], "0 and true are not 'equal'");
+    $assert = fu::assert_not_equal(null, 1);
+    fu::strict_equal(true, $assert['result'], "null and 1 are not 'equal'");
+    $assert = fu::assert_not_equal(true, null);
+    fu::strict_equal(true, $assert['result'], "false and null are not 'equal'");
+    $assert = fu::assert_not_equal(array('0'), null);
+    fu::strict_equal(true, $assert['result'], "array('0') and null are not 'equal'");
 });
 
 fu::test('FUnit::assert_strict_equal tests', function () {
-    fu::strict_equal(true, fu::assert_strict_equal(1, 1)['result'], "1 and 1 are strict equal");
-    fu::strict_equal(true, fu::assert_strict_equal("a", "a")['result'], "'a' and 'a' are strict equal");
+    $assert = fu::assert_strict_equal(1, 1);
+    fu::strict_equal(true, $assert['result'], "1 and 1 are strict equal");
+    $assert = fu::assert_strict_equal("a", "a");
+    fu::strict_equal(true, $assert['result'], "'a' and 'a' are strict equal");
     $a = new StdClass;
     $b = $a;
-    fu::strict_equal(true, fu::assert_strict_equal($a, $b)['result'], "\$a and \$b refer to same object, so strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(new stdClass, new stdClass)['result'], "new stdClass and new stdClass are not strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(1, "1")['result'], "1 and '1' are not strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(1, true)['result'], "1 and true are not strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(null, 0)['result'], "null and 0 are not strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(false, null)['result'], "false and null are not strict equal");
-    fu::strict_equal(false, fu::assert_strict_equal(array(), null)['result'], "array() and null are not strict equal");
+    $assert = fu::assert_strict_equal($a, $b);
+    fu::strict_equal(true, $assert['result'], "\$a and \$b refer to same object, so strict equal");
+    $assert = fu::assert_strict_equal(new stdClass, new stdClass);
+    fu::strict_equal(false, $assert['result'], "new stdClass and new stdClass are not strict equal");
+    $assert = fu::assert_strict_equal(1, "1");
+    fu::strict_equal(false, $assert['result'], "1 and '1' are not strict equal");
+    $assert = fu::assert_strict_equal(1, true);
+    fu::strict_equal(false, $assert['result'], "1 and true are not strict equal");
+    $assert = fu::assert_strict_equal(null, 0);
+    fu::strict_equal(false, $assert['result'], "null and 0 are not strict equal");
+    $assert = fu::assert_strict_equal(false, null);
+    fu::strict_equal(false, $assert['result'], "false and null are not strict equal");
+    $assert = fu::assert_strict_equal(array(), null);
+    fu::strict_equal(false, $assert['result'], "array() and null are not strict equal");
 });
 
 fu::test('FUnit::assert_not_strict_equal tests', function () {
-    fu::strict_equal(false, fu::assert_not_strict_equal(1, 1)['result'], "1 and 1 are strict equal");
-    fu::strict_equal(false, fu::assert_not_strict_equal("a", "a")['result'], "'a' and 'a' are strict equal");
+    $assert = fu::assert_not_strict_equal(1, 1);
+    fu::strict_equal(false, $assert['result'], "1 and 1 are strict equal");
+    $assert = fu::assert_not_strict_equal("a", "a");
+    fu::strict_equal(false, $assert['result'], "'a' and 'a' are strict equal");
     $a = new StdClass;
     $b = $a;
-    fu::strict_equal(false, fu::assert_not_strict_equal($a, $b)['result'], "\$a and \$b refer to same object, so strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(new stdClass, new stdClass)['result'], "new stdClass and new stdClass are not strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(1, "1")['result'], "1 and '1' are not strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(1, true)['result'], "1 and true are not strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(null, 0)['result'], "null and 0 are not strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(false, null)['result'], "false and null are not strict equal");
-    fu::strict_equal(true, fu::assert_not_strict_equal(array(), null)['result'], "array() and null are not strict equal");
+    $assert = fu::assert_not_strict_equal($a, $b);
+    fu::strict_equal(false, $assert['result'], "\$a and \$b refer to same object, so strict equal");
+    $assert = fu::assert_not_strict_equal(new stdClass, new stdClass);
+    fu::strict_equal(true, $assert['result'], "new stdClass and new stdClass are not strict equal");
+    $assert = fu::assert_not_strict_equal(1, "1");
+    fu::strict_equal(true, $assert['result'], "1 and '1' are not strict equal");
+    $assert = fu::assert_not_strict_equal(1, true);
+    fu::strict_equal(true, $assert['result'], "1 and true are not strict equal");
+    $assert = fu::assert_not_strict_equal(null, 0);
+    fu::strict_equal(true, $assert['result'], "null and 0 are not strict equal");
+    $assert = fu::assert_not_strict_equal(false, null);
+    fu::strict_equal(true, $assert['result'], "false and null are not strict equal");
+    $assert = fu::assert_not_strict_equal(array(), null);
+    fu::strict_equal(true, $assert['result'], "array() and null are not strict equal");
 });
 
 fu::test('FUnit::assert_throws tests', function () {
     $callback = function () {
         throw new RuntimeException();
     };
-    $rs = fu::assert_throws($callback, 'RuntimeException')['result'];
+    $assert = fu::assert_throws($callback, 'RuntimeException');
+    $rs = $assert['result'];
     fu::strict_equal(true, $rs, "callback threw correct exception type");
 
     $callback = function ($foo) {
         throw new RuntimeException($foo);
     };
-    $rs = fu::assert_throws($callback, array('bar'), 'LogicException')['result'];
+    $assert = fu::assert_throws($callback, array('bar'), 'LogicException');
+    $rs = $assert['result'];
     fu::strict_equal(false, $rs, "callback didn't throw correct exception type");
 });
 
@@ -140,15 +213,23 @@ fu::test('FUnit::assert_has tests', function () {
     $obj->bar = null;
     $obj->baz = "bingo";
 
-    fu::strict_equal(true, fu::assert_has('foo', $arr)['result'], "\$arr has key 'foo'");
-    fu::strict_equal(true, fu::assert_has('bar', $arr)['result'], "\$arr has key 'bar'");
-    fu::strict_equal(true, fu::assert_has('baz', $arr)['result'], "\$arr has key 'baz'");
-    fu::strict_equal(false, fu::assert_has('bingo', $arr)['result'], "\$arr does not have key 'bingo'");
+    $assert = fu::assert_has('foo', $arr);
+    fu::strict_equal(true, $assert['result'], "\$arr has key 'foo'");
+    $assert = fu::assert_has('bar', $arr);
+    fu::strict_equal(true, $assert['result'], "\$arr has key 'bar'");
+    $assert = fu::assert_has('baz', $arr);
+    fu::strict_equal(true, $assert['result'], "\$arr has key 'baz'");
+    $assert = fu::assert_has('bingo', $arr);
+    fu::strict_equal(false, $assert['result'], "\$arr does not have key 'bingo'");
 
-    fu::strict_equal(true, fu::assert_has('foo', $obj)['result'], "\$obj has property 'foo'");
-    fu::strict_equal(true, fu::assert_has('bar', $obj)['result'], "\$obj has property 'bar'");
-    fu::strict_equal(true, fu::assert_has('baz', $obj)['result'], "\$obj has property 'baz'");
-    fu::strict_equal(false, fu::assert_has('bingo', $obj)['result'], "\$obj does not have property 'bingo'");
+    $assert = fu::assert_has('foo', $obj);
+    fu::strict_equal(true, $assert['result'], "\$obj has property 'foo'");
+    $assert = fu::assert_has('bar', $obj);
+    fu::strict_equal(true, $assert['result'], "\$obj has property 'bar'");
+    $assert = fu::assert_has('baz', $obj);
+    fu::strict_equal(true, $assert['result'], "\$obj has property 'baz'");
+    $assert = fu::assert_has('bingo', $obj);
+    fu::strict_equal(false, $assert['result'], "\$obj does not have property 'bingo'");
 
 });
 
@@ -165,31 +246,44 @@ fu::test('FUnit::assert_not_has tests', function () {
     $obj->bar = null;
     $obj->baz = "bingo";
 
-    fu::strict_equal(false, fu::assert_not_has('foo', $arr)['result'], "\$arr has key 'foo'");
-    fu::strict_equal(false, fu::assert_not_has('bar', $arr)['result'], "\$arr has key 'bar'");
-    fu::strict_equal(false, fu::assert_not_has('baz', $arr)['result'], "\$arr has key 'baz'");
-    fu::strict_equal(true, fu::assert_not_has('bingo', $arr)['result'], "\$arr does not have key 'bingo'");
+    $assert = fu::assert_not_has('foo', $arr);
+    fu::strict_equal(false, $assert['result'], "\$arr has key 'foo'");
+    $assert = fu::assert_not_has('bar', $arr);    
+    fu::strict_equal(false, $assert['result'], "\$arr has key 'bar'");
+    $assert = fu::assert_not_has('baz', $arr);    
+    fu::strict_equal(false, $assert['result'], "\$arr has key 'baz'");
+    $assert = fu::assert_not_has('bingo', $arr);    
+    fu::strict_equal(true, $assert['result'], "\$arr does not have key 'bingo'");
 
-    fu::strict_equal(false, fu::assert_not_has('foo', $obj)['result'], "\$obj has property 'foo'");
-    fu::strict_equal(false, fu::assert_not_has('bar', $obj)['result'], "\$obj has property 'bar'");
-    fu::strict_equal(false, fu::assert_not_has('baz', $obj)['result'], "\$obj has property 'baz'");
-    fu::strict_equal(true, fu::assert_not_has('bingo', $obj)['result'], "\$obj does not have property 'bingo'");
+    $assert = fu::assert_not_has('foo', $obj);
+    fu::strict_equal(false, $assert['result'], "\$obj has property 'foo'");
+    $assert = fu::assert_not_has('bar', $obj);    
+    fu::strict_equal(false, $assert['result'], "\$obj has property 'bar'");
+    $assert = fu::assert_not_has('baz', $obj);    
+    fu::strict_equal(false, $assert['result'], "\$obj has property 'baz'");
+    $assert = fu::assert_not_has('bingo', $obj);    
+    fu::strict_equal(true, $assert['result'], "\$obj does not have property 'bingo'");
 });
 
 
 fu::test('FUnit::assert_fail tests', function () {
-    fu::strict_equal(false, fu::assert_fail()['result'], "forced fail");
+    $assert = fu::assert_fail();
+    fu::strict_equal(false, $assert['result'], "forced fail");
 });
 fu::test('FUnit::assert_expect_fail tests', function () {
-    fu::strict_equal(false, fu::assert_expect_fail()['result'], "forced expected fail");
+    $assert = fu::assert_expect_fail();
+    fu::strict_equal(false, $assert['result'], "forced expected fail");
 });
 fu::test('FUnit::assert_pass tests', function () {
-    fu::strict_equal(true, fu::assert_pass()['result'], "forced pass");
+    $assert = fu::assert_pass();
+    fu::strict_equal(true, $assert['result'], "forced pass");
 });
 
 fu::test('Ensure not including msg param has no side effects', function () {
-    fu::strict_equal(true, fu::assert_equal(1, 1, 'poop')['result']);
-    fu::strict_equal(true, fu::assert_equal(1, 1)['result']);
+    $assert = fu::assert_equal(1, 1, 'poop');
+    fu::strict_equal(true, $assert['result']);
+    $assert = fu::assert_equal(1, 1);
+    fu::strict_equal(true, $assert['result']);
 });
 
 

--- a/tests/assertion_tests.php
+++ b/tests/assertion_tests.php
@@ -62,6 +62,15 @@ fu::test('FUnit::assert_all_ok tests', function () {
         return is_int($val);
     });
     fu::strict_equal(false, $assert['result'], "\$not_all_ints are NOT all integers");
+
+    try {
+        fu::assert_all_ok($all_ints, 'not callable');
+    } catch (\Exception $e) {
+        fu::ok(
+            $e instanceof \InvalidArgumentException,
+            'throws InvalidArgumentException if no valid callback is provided'
+        );
+    }
 });
 
 
@@ -198,6 +207,15 @@ fu::test('FUnit::assert_throws tests', function () {
     $assert = fu::assert_throws($callback, array('bar'), 'LogicException');
     $rs = $assert['result'];
     fu::strict_equal(false, $rs, "callback didn't throw correct exception type");
+    
+    try {
+        fu::assert_throws('not callable', array());
+    } catch (\Exception $e) {
+        fu::ok(
+            $e instanceof \InvalidArgumentException,
+            'throws InvalidArgumentException if no valid callback is provided'
+        );
+    }
 });
 
 fu::test('FUnit::assert_has tests', function () {


### PR DESCRIPTION
Hello, 

in your README.md file you mention that _"FUnit is a testing microframework for PHP 5.3+..."_. After using it to test my projects, i noticed that the methods **throws** and **all_ok** fail when using php 5.3 throwing the following error:

```
CATCHABLE FATAL ERROR: Argument 2 passed to FUnit::assert_all_ok() must be an instance of callable, instance of Closure given, called in <<test file>> on line 58 and defined in ...
```

These two methods use the php type hint **callable**, which is available in php >= 5.4 ([Callbacks / Callables](http://php.net/manual/en/language.types.callable.php)).

Also, the unit tests do not work in php 5.3 because of the array dereference, also supported by php >= 5.4.

I' ve enabled the FUnit's methods **throws** and **all_ok** to accept any callables and also updated the unit tests in order to work with php 5.3.

Tell me what you think about it !
